### PR TITLE
Feature/update the build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 mkdir -p build
 java -jar deps/yuicompressor-2.4.7.jar --type js --charset utf-8 -v --nomunge --preserve-semi --disable-optimizations src/calabash.js > calabash-min.tmp.js
 java -jar deps/yuicompressor-2.4.7.jar --type js --charset utf-8 -v --nomunge --preserve-semi --disable-optimizations src/set_text.js > set_text-min.tmp.js

--- a/build.sh
+++ b/build.sh
@@ -2,13 +2,16 @@
 
 rm -rf build
 mkdir -p build
-rm -f *-min.tmp.js
 
-java -jar deps/yuicompressor-2.4.7.jar --type js --charset utf-8 -v --nomunge --preserve-semi --disable-optimizations src/calabash.js > calabash-min.tmp.js
-java -jar deps/yuicompressor-2.4.7.jar --type js --charset utf-8 -v --nomunge --preserve-semi --disable-optimizations src/set_text.js > set_text-min.tmp.js
+CALABASH_TMP_JS=build/calabash-min.tmp.js
+SET_TEXT_TMP_JS=build/set_text-min.tmp.js
 
-sed "s/\"/'/g" calabash-min.tmp.js > build/calabash-min.js
-sed "s/\"/'/g" set_text-min.tmp.js > build/set_text-min.js
+java -jar deps/yuicompressor-2.4.7.jar --type js --charset utf-8 -v --nomunge --preserve-semi --disable-optimizations src/calabash.js > $CALABASH_TMP_JS
+java -jar deps/yuicompressor-2.4.7.jar --type js --charset utf-8 -v --nomunge --preserve-semi --disable-optimizations src/set_text.js > $SET_TEXT_TMP_JS
 
-rm -f *-min.tmp.js
+sed "s/\"/'/g" $CALABASH_TMP_JS > build/calabash-min.js
+sed "s/\"/'/g" $SET_TEXT_TMP_JS > build/set_text-min.js
+
+rm -f $CALABASH_TMP_JS
+rm -f $SET_TEXT_TMP_JS
 

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
+
+rm -rf build
 mkdir -p build
+rm -f *-min.tmp.js
+
 java -jar deps/yuicompressor-2.4.7.jar --type js --charset utf-8 -v --nomunge --preserve-semi --disable-optimizations src/calabash.js > calabash-min.tmp.js
 java -jar deps/yuicompressor-2.4.7.jar --type js --charset utf-8 -v --nomunge --preserve-semi --disable-optimizations src/set_text.js > set_text-min.tmp.js
 
 sed "s/\"/'/g" calabash-min.tmp.js > build/calabash-min.js
 sed "s/\"/'/g" set_text-min.tmp.js > build/set_text-min.js
-rm *-min.tmp.js
+
+rm -f *-min.tmp.js
+


### PR DESCRIPTION
### Motivation

The build script should respect the user's bash env.

It should also confine its build products to the `build` directory.
